### PR TITLE
Quick UI fixes

### DIFF
--- a/frontend/battle-royale-ui/src/Board.jsx
+++ b/frontend/battle-royale-ui/src/Board.jsx
@@ -24,6 +24,8 @@ const TRAVELLING = 0;
 const SHOOTING = 1;
 const DONE = 2;
 
+const MAX_RADIUS = 9;
+
 const isReachable = (destination, origin, distance) => {
   const originHex = new Hex(origin.q, origin.r, origin.r * -1 - origin.q);
   const destinationHex = new Hex(destination.q, destination.r, destination.r * -1 - destination.q);
@@ -64,7 +66,7 @@ export default function Board({
     return { x: -1 * factor * x * radius + maxRadius, y: -1 * factor * y * radius  + maxRadius };
   }
 
-  const hexagonSize = calcSize({x: 1, y: 1}, center.q, 10);
+  const hexagonSize = calcSize({x: 1, y: 1}, center.q, MAX_RADIUS);
   const islandSize = {x: hexagonSize.x * 0.866, y: hexagonSize.y * 1};
   const waterSize = islandSize
 

--- a/frontend/battle-royale-ui/src/CommitMoveButton.jsx
+++ b/frontend/battle-royale-ui/src/CommitMoveButton.jsx
@@ -185,7 +185,8 @@ export default function CommitMoveButton({ travelEndpoint, shotEndpoint, myShip,
         shotDistance,
       });
       setTxInFlight(true);
-      clearTravelAndShotEndpoints();
+      // clearTravelAndShotEndpoints() shouldn't be called here, so that the highlighting is not removed before the transaction is confirmed
+      // clearTravelAndShotEndpoints();
     } catch (error) {
       console.error(
         "Error in submitting moves or storing in DynamoDB",


### PR DESCRIPTION
two UI fixes:
1. hex cells don't get cut off anymore because the layout calculation was wrong
2. travel and shot endpoints do not get reset when a move is submitted. This should fix the wiggly lines after commit